### PR TITLE
fixes for titan/pro

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -110,7 +110,7 @@
 
 // Optional custom name for your RepStrap or other custom machine
 // Displayed in the LCD "Ready" message
-#define CUSTOM_MACHINE_NAME "BigBox Dual"
+#define CUSTOM_MACHINE_NAME "BigBox Pro"
 
 // Define this to set a unique identifier for this printer, (Used by some programs to differentiate between machines)
 // You can use an online service to generate a random UUID. (eg http://www.uuidgenerator.net/version4)
@@ -500,7 +500,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 // @section machine
 
 // Travel limits after homing (units are in mm)
-#define X_MIN_POS -38
+#define X_MIN_POS 0
 #define Y_MIN_POS 0
 #define Z_MIN_POS 0
 #define X_MAX_POS 300
@@ -678,7 +678,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define Z_SAFE_HOMING
 
 #if ENABLED(Z_SAFE_HOMING)
-  #define Z_SAFE_HOMING_X_POINT (30)    // X point for Z homing when homing all axis (G28).
+  #define Z_SAFE_HOMING_X_POINT (70)    // X point for Z homing when homing all axis (G28).
   #define Z_SAFE_HOMING_Y_POINT (30)    // Y point for Z homing when homing all axis (G28).
 #endif
 


### PR DESCRIPTION
- renamed Dual to Pro
- moved X_MIN_POS from -38 to 0, moved HOMING_X from 30 to 70 to acommodate that the PRO has only one extruder in the Right slot
